### PR TITLE
Make Java 7 JDK download to cache configurable via Ansible

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 java_packages: []
 java_cleanup: True
+java7_cache_download_src_url_enabled: False
+java7_cache_download_src_base_url: "<src_base_url>"
+java7_cache_download_src_filename: "<filename>"

--- a/tasks/webupd8_for_debian.yml
+++ b/tasks/webupd8_for_debian.yml
@@ -11,6 +11,20 @@
   apt_repository: repo='deb http://ppa.launchpad.net/webupd8team/java/ubuntu precise main' state=present
   when: java_needs_oracle
 
+- name: Create Java 7 Cache Directory
+  file: path=/var/cache/oracle-jdk7-installer state=directory
+  with_items:
+    - oracle-java7-installer
+  when: java_needs_oracle and java7_cache_download_src_url_enabled
+
+- name: Download Java 7 from URL
+  get_url:
+    url: '{{java7_cache_download_src_base_url}}{{java7_cache_download_src_filename}}'
+    dest: '/var/cache/oracle-jdk7-installer/{{java7_cache_download_src_filename}}'
+  with_items:
+    - oracle-java7-installer
+  when: java_needs_oracle and java7_cache_download_src_url_enabled
+
 - name: Remove WebUpd8 Team Java PPA (for Oracle Java)
   apt_repository: repo='deb http://ppa.launchpad.net/webupd8team/java/ubuntu precise main' state=present
   when: java_cleanup and not java_needs_oracle


### PR DESCRIPTION
Oracle has pulled Java 7 JDK downloads since they are no longer current. For apps that are still running them this allows the JDK url to be specified where to pull from and will be put into `/var/cache/oracle-jdk7-installer` when flag is enabled (defaults to false).