### PR TITLE
Make Java 7 JDK download to cache configurable via Ansible for Ubuntu

### DIFF
--- a/tasks/webupd8_for_debian.yml
+++ b/tasks/webupd8_for_debian.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install WebUpd8 apt key
   apt_key: id=EEA14886 keyserver='keyserver.ubuntu.com' state=present
   register: webupd8key

--- a/tasks/webupd8_for_ubuntu.yml
+++ b/tasks/webupd8_for_ubuntu.yml
@@ -7,6 +7,20 @@
   retries: 5
   delay: 10
 
+- name: Create Java 7 Cache Directory
+  file: path=/var/cache/oracle-jdk7-installer state=directory
+  with_items:
+    - oracle-java7-installer
+  when: java_needs_oracle and java7_cache_download_src_url_enabled
+
+- name: Download Java 7 from URL
+  get_url:
+    url: '{{java7_cache_download_src_base_url}}{{java7_cache_download_src_filename}}'
+    dest: '/var/cache/oracle-jdk7-installer/{{java7_cache_download_src_filename}}'
+  with_items:
+    - oracle-java7-installer
+  when: java_needs_oracle and java7_cache_download_src_url_enabled
+
 - name: Remove WebUpd8 Team Java PPA (for Oracle Java)
   apt_repository: repo='ppa:webupd8team/java' state=present
   when: java_cleanup and not java_needs_oracle


### PR DESCRIPTION
Previously added for Debian, but we want this to work for Ubuntu as well.