### PR TITLE
Use present packages if possible, otherwise fall back to latest

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -20,7 +20,7 @@
   when: java_needs_oracle
 
 - name: Install Java packages
-  apt: pkg={{ item }} state=latest
+  apt: pkg={{ item }} state=present
   with_items: java_packages
 
 - name: Remove unwanted Java packages


### PR DESCRIPTION
@rappleg @dmart 

This will resolve the issue for anyone who uses our releng base AMI (`smartthings/legacy_base-trusty-*`) burned from Spinnaker, which has the Java packages burned onto it.