### PR TITLE
oracle jdk is no longer available, skip trying to install it

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,2 @@
 ---
-java_needs_oracle: "{{ java_packages | join | search('oracle') }}"
+java_needs_oracle: False


### PR DESCRIPTION
this will allow us to build new base amis with oracle installed from another source